### PR TITLE
GEN-609_정의되지 않은 값이 들어올 경우 예외 처리

### DIFF
--- a/pod.py
+++ b/pod.py
@@ -168,7 +168,10 @@ class Pod():
                 print(f"Skipping invalid PID in line: {line}")
                 continue
             p.comm = fields[1].strip('()')
-            p.state = Mode_State[fields[2]].value
+            try:  # for undefined code
+                p.state = Mode_State[fields[2]].value
+            except KeyError:
+                p.state = f"Unknown({fields[2]})"
             p.ppid = int(fields[3])
             p.pgrp = int(fields[4])
             p.session = int(fields[5])


### PR DESCRIPTION
- 프로세스 정보 로깅 중 오류 발생
    - 항목 중 프로세스 상태 코드가 `Mode_State`에 존재하지 않는 ’X’라는 값이 들어옴

- 프로세스 상태 “X”
    - X = Dead
    - 완전히 죽어 있는 프로세스를 의미함
    - 보기 드문 상태이며, 커널 내부에서 프로세스가 강제로 종료되거나 비정상적인 상태로 제거된 경우에 발생 가능
- 예외 처리
    
    ```python
    p.comm = fields[1].strip('()')
    try:  # for undefined code
        p.state = Mode_State[fields[2]].value
    except KeyError:
        p.state = f"Unknown({fields[2]})"
    ```
    
    - 에러날 경우 Unknown과 프로세스 상태 코드를 같이 저장