### PR TITLE
GEN-1070 GC 분석/판단 단계 멀티스레드 병렬화

### DIFF
--- a/garbagecollector.py
+++ b/garbagecollector.py
@@ -78,9 +78,21 @@ class GarbageCollector():
                 self.resourceCollector.collect_and_save()
 
                 # 3단계: GC 판단 및 삭제
-                for p_name, p_obj in self.podlist.items():
-                    should_gc, gc_reason, cause = p_obj.shouldGarbageCollection()
+                decisions = []
+                with ThreadPoolExecutor(max_workers=worker) as executor:
+                    decide_futures = {
+                        executor.submit(p_obj.shouldGarbageCollection): (p_name, p_obj)
+                        for p_name, p_obj in self.podlist.items()
+                    }
+                    for fut in as_completed(decide_futures):
+                        p_name, p_obj = decide_futures[fut]
+                        try:
+                            should_gc, gc_reason, cause = fut.result()
+                            decisions.append((p_name, p_obj, should_gc, gc_reason, cause))
+                        except Exception as e:
+                            print(f"[WARN] Fail to analyze pod {p_name}: {e}")
 
+                for p_name, p_obj, should_gc, gc_reason, cause in decisions:
                     if should_gc:
                         print(f"\n[Garbage Collector] Pod '{p_name}' will be deleted")
                         print(f"  Reason: {gc_reason}")
@@ -177,6 +189,6 @@ if __name__ == "__main__":
     initialize_database()  # PostgreSQL DB 초기화
 
     #네임스페이스 값을 비워두면 'default'로 지정
-    gc = GarbageCollector(namespace='swlabpods', isDev=False)
+    gc = GarbageCollector(namespace='swlabpods', isDev=False, Inactive_Threshold_s=20 * 60)
     gc.manage()
     # gc.logging()

--- a/pod.py
+++ b/pod.py
@@ -539,9 +539,7 @@ class Pod:
         self.isActiveFromProcess()
 
         # 3. 판단
-        if not self.isActiveResultCommandHistory:
-            return True, 'No usage history for more than a week', 'history'
-        if not self.isActiveResultProcess:
-            return True, self.processStateDescription, 'process'
+        if not self.isActiveResultCommandHistory and not self.isActiveResultProcess:
+            return True, f'No usage history for more than a week & {self.processStateDescription}', 'history+process'
         else:
             return False, 'active', None

--- a/processManager.py
+++ b/processManager.py
@@ -432,8 +432,8 @@ class ProcessManager:
         """
         deltas = {}
         deltas['CPUtime'] = (p.utime + p.stime) - (prev.get('utime', 0) + prev.get('stime', 0))
-        deltas['voluntary_ctxt'] = p.metrics.voluntary_ctxt_switches - prev.get('voluntary_ctxt', 0)
-        deltas['nonvoluntary_ctxt'] = p.metrics.nonvoluntary_ctxt_switches - prev.get('nonvoluntary_ctxt', 0)
+        deltas['voluntary_ctxt'] = (p.metrics.voluntary_ctxt_switches or 0) - prev.get('voluntary_ctxt', 0)
+        deltas['nonvoluntary_ctxt'] = (p.metrics.nonvoluntary_ctxt_switches or 0) - prev.get('nonvoluntary_ctxt', 0)
         deltas['rss'] = (p.rss or 0) - prev.get('rss', 0)
         deltas['minflt'] = p.minflt - prev.get('minflt', 0)
         deltas['io_bytes'] = ((p.metrics.read_bytes or 0) + (p.metrics.write_bytes or 0)) - prev.get('io_bytes', 0)


### PR DESCRIPTION
## 변경 사항
- 3단계 GC 판단(shouldGarbageCollection)을 ThreadPoolExecutor로 파드별 병렬 처리,
  삭제 및 podlist 변경은 메인 스레드에서 순차 처리하도록 분리 (db0933e)
- 실행 설정 Inactive_Threshold_s=20분 적용 (db0933e)
- GC 판단 조건을 "히스토리 OR 프로세스" → "히스토리 AND 프로세스"로 변경
  (둘 다 비활성일 때만 GC 대상) (fb576c4)