### PR TITLE
GEN-1070: 멀티스레드 분석 + 프로세스 분석 DB 저장 + in-cluster 배포/CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.venv
+.idea
+__pycache__
+*.pyc
+error.log
+data
+history
+deploy
+simulator
+sleep_cpu_activity
+pod_generation
+tool
+api_py
+*.log

--- a/DB_postgresql.py
+++ b/DB_postgresql.py
@@ -178,6 +178,53 @@ def initialize_database():
         );
         """)
 
+        # pod analysis Table (사이클별 파드 단위 프로세스 분석 요약 = summary)
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS pod_analysis (
+            id SERIAL PRIMARY KEY,
+            pod_id INTEGER REFERENCES pod_info(pod_id) ON DELETE CASCADE,
+            timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            experiment_id INTEGER,
+            status VARCHAR(20),
+            description TEXT,
+            total INTEGER,
+            active INTEGER,
+            inactive INTEGER,
+            zombie INTEGER
+        );
+        """)
+
+        # Process metrics (/proc/[pid]/status, /proc/[pid]/io) Table (process_data와 1:1)
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS process_metrics (
+            id SERIAL PRIMARY KEY,
+            process_data_id INTEGER REFERENCES process_data(id) ON DELETE CASCADE,
+            voluntary_ctxt_switches BIGINT,
+            nonvoluntary_ctxt_switches BIGINT,
+            vm_rss BIGINT,
+            read_bytes BIGINT,
+            write_bytes BIGINT
+        );
+        """)
+
+        # process classification Table (프로세스 단위 활성/비활성 분류 = classification)
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS process_classification (
+            id SERIAL PRIMARY KEY,
+            analysis_id INTEGER REFERENCES pod_analysis(id) ON DELETE CASCADE,
+            pid INTEGER,
+            comm VARCHAR(255),
+            state VARCHAR(20),
+            reason VARCHAR(50),
+            cputime_delta BIGINT,
+            ctxt_delta BIGINT,
+            non_ctxt_delta BIGINT,
+            rss_delta BIGINT,
+            minflt_delta BIGINT,
+            io_delta BIGINT
+        );
+        """)
+
         conn.commit()
 
     except psycopg2.Error as e:
@@ -356,13 +403,22 @@ def save_to_process(pod_name, namespace, processes):
             processor, rt_priority, policy, delayacct_blkio_ticks, guest_time, cguest_time, start_data, end_data, start_brk, arg_start,
             arg_end, env_start, env_end, exit_code
         ) VALUES (
-            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 
-            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 
-            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 
-            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 
-            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 
+            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
             %s, %s, %s, %s
-        )
+        ) RETURNING id;
+        """
+
+        insert_metrics = """
+        INSERT INTO process_metrics (
+            process_data_id, voluntary_ctxt_switches, nonvoluntary_ctxt_switches,
+            vm_rss, read_bytes, write_bytes
+        ) VALUES (
+            %s, %s, %s, %s, %s, %s
+        );
         """
 
         for process in processes:
@@ -382,6 +438,13 @@ def save_to_process(pod_name, namespace, processes):
             )
 
             cursor.execute(insert_query, values)
+            process_data_id = cursor.fetchone()[0]
+
+            cursor.execute(insert_metrics, (
+                process_data_id,
+                process['voluntary_ctxt_switches'], process['nonvoluntary_ctxt_switches'],
+                process['vm_rss'], process['read_bytes'], process['write_bytes']
+            ))
         conn.commit()
     except psycopg2.Error as e:
         logging.error(f"PostgreSQL Error: {e}")
@@ -389,6 +452,70 @@ def save_to_process(pod_name, namespace, processes):
         if conn:
             cursor.close()
             conn.close()
+
+
+def save_pod_analysis(pod_name, namespace, analysis):
+    """
+    파드 단위 프로세스 분석 결과 저장 (summary + classification)
+    pod_analysis(부모, summary) 1행 저장 후 그 id로 process_classification(자식) bulk 저장.
+    analysis = {
+        timestamp, experiment_id, status, description,
+        total, active, inactive, zombie,
+        classifications: [{pid, comm, state, reason,
+                           cputime_delta, ctxt_delta, non_ctxt_delta,
+                           rss_delta, minflt_delta, io_delta}, ...]
+    }
+    """
+    conn = None
+
+    try:
+        conn = get_db_connection()
+        if conn is None:
+            logging.error("Database connection failed")
+            return None
+
+        cursor = conn.cursor()
+
+        pod_id = get_or_create_pod_id(pod_name, namespace)
+
+        cursor.execute("""
+        INSERT INTO pod_analysis (
+            pod_id, timestamp, experiment_id, status, description,
+            total, active, inactive, zombie
+        ) VALUES (
+            %s, %s, %s, %s, %s, %s, %s, %s, %s
+        ) RETURNING id;
+        """, (
+            pod_id, analysis['timestamp'], analysis['experiment_id'],
+            analysis['status'], analysis['description'],
+            analysis['total'], analysis['active'], analysis['inactive'], analysis['zombie']
+        ))
+        analysis_id = cursor.fetchone()[0]
+
+        insert_classification = """
+        INSERT INTO process_classification (
+            analysis_id, pid, comm, state, reason,
+            cputime_delta, ctxt_delta, non_ctxt_delta, rss_delta, minflt_delta, io_delta
+        ) VALUES (
+            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+        );
+        """
+
+        for c in analysis.get('classifications', []):
+            cursor.execute(insert_classification, (
+                analysis_id, c['pid'], c['comm'], c['state'], c['reason'],
+                c['cputime_delta'], c['ctxt_delta'], c['non_ctxt_delta'],
+                c['rss_delta'], c['minflt_delta'], c['io_delta']
+            ))
+
+        conn.commit()
+    except psycopg2.Error as e:
+        logging.error(f"PostgreSQL Error (pod_analysis): {e}")
+    finally:
+        if conn:
+            cursor.close()
+            conn.close()
+
 
 def save_bash_history(pod_name, namespace, last_modified):
     """bash_history data seve to DB"""

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY *.py ./
+COPY config.ini ./
+
+ENV PYTHONUNBUFFERED=1
+
+ENTRYPOINT ["python", "garbagecollector.py"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,72 @@
+// Kube_Management_System (Garbage Collector) — Jenkins Pipeline
+// - main 브랜치만 빌드·푸시·배포, 그 외 브랜치는 Checkout 만 수행
+// - 이미지: harbor.cu.ac.kr/swlabpods/gc
+// - 배포 대상: k8s-gc 네임스페이스 Deployment/garbage-collector (deploy/gc-deployment.yaml)
+
+pipeline {
+    agent any
+
+    options {
+        timeout(time: 20, unit: 'MINUTES')
+        disableConcurrentBuilds()
+    }
+
+    environment {
+        REGISTRY   = 'harbor.cu.ac.kr'
+        IMAGE      = 'swlabpods/gc'
+        NAMESPACE  = 'k8s-gc'
+        DEPLOYMENT = 'garbage-collector'
+    }
+
+    stages {
+
+        stage('Checkout') {
+            steps { checkout scm }
+        }
+
+        stage('환경 결정') {
+            when { branch 'main' }
+            steps {
+                script {
+                    // 태그 = BUILD_NUMBER-GIT_SHA. 잡을 재생성해 번호가 1 부터 재시작해도
+                    // 커밋 SHA 가 달라 Harbor 의 기존 태그를 덮어쓰지 않는다(불변성 보장).
+                    env.GIT_SHA   = sh(script: 'git rev-parse --short=7 HEAD', returnStdout: true).trim()
+                    env.IMAGE_TAG = "${env.BUILD_NUMBER}-${env.GIT_SHA}"
+                    echo "branch=${env.BRANCH_NAME} image=${REGISTRY}/${IMAGE}:${env.IMAGE_TAG}"
+                }
+            }
+        }
+
+        stage('Build & Push') {
+            when { branch 'main' }
+            steps {
+                script {
+                    def img = docker.build("${REGISTRY}/${IMAGE}:${IMAGE_TAG}", ".")
+                    docker.withRegistry("https://${REGISTRY}", 'harbor') {
+                        img.push()
+                        img.push('latest')
+                    }
+                }
+            }
+        }
+
+        stage('Deploy') {
+            when { branch 'main' }
+            steps {
+                sh """
+                    set -e
+
+                    # RBAC(SA/Role/RoleBinding) + Deployment 보장. 이미 있으면 unchanged.
+                    kubectl apply -f deploy/gc-deployment.yaml
+
+                    # 이미지 태그 교체 (latest → BUILD_NUMBER-GIT_SHA) 로 롤아웃 트리거
+                    kubectl -n ${NAMESPACE} set image deployment/${DEPLOYMENT} \\
+                        ${DEPLOYMENT}=${REGISTRY}/${IMAGE}:${IMAGE_TAG}
+
+                    kubectl -n ${NAMESPACE} rollout status deployment/${DEPLOYMENT} --timeout=3m
+                """
+            }
+        }
+
+    }
+}

--- a/deploy/gc-deployment.yaml
+++ b/deploy/gc-deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: garbage-collector
+  namespace: k8s-gc
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: garbage-collector
+  namespace: swlabpods
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "get"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["list"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: garbage-collector
+  namespace: swlabpods
+subjects:
+  - kind: ServiceAccount
+    name: garbage-collector
+    namespace: k8s-gc
+roleRef:
+  kind: Role
+  name: garbage-collector
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: garbage-collector
+  namespace: k8s-gc
+  labels:
+    app: garbage-collector
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: garbage-collector
+  template:
+    metadata:
+      labels:
+        app: garbage-collector
+    spec:
+      serviceAccountName: garbage-collector
+      containers:
+        - name: garbage-collector
+          image: harbor.cu.ac.kr/swlabpods/gc:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"

--- a/garbagecollector.py
+++ b/garbagecollector.py
@@ -12,7 +12,10 @@ from multiprocessing import Event
 
 class GarbageCollector():
     def __init__(self, namespace='default', container=None, isDev=False, stop_event=None, Inactive_Threshold_s=None):
-        config.load_kube_config()  # 필수 config값 불러옴
+        try:
+            config.load_incluster_config()
+        except config.ConfigException:
+            config.load_kube_config()  # 필수 config값 불러옴
         self.v1 = client.CoreV1Api()  # api
         self.namespace: str = namespace
         self.container = container

--- a/historyManager.py
+++ b/historyManager.py
@@ -40,10 +40,10 @@ class HistoryManager():
             last = int(exec_command.strip())
             return last
         except FileNotFoundError as e:
-            print("File not found")
+            print(f"No bash_history found for pod: {self.pod.metadata.name}")
             return None
         except Exception as e:
-            print(f"occured error: {e}")
+            print(f"bash_history error for pod {self.pod.metadata.name}: {e}")
             return None
 
     def getNowTime(self):

--- a/pod.py
+++ b/pod.py
@@ -13,7 +13,8 @@ from DB_postgresql import (
     save_bash_history,
     save_delete_reason,
     is_deleted_in_DB, is_exist_in_DB,
-    update_pod_lifecycle_creation_if_empty
+    update_pod_lifecycle_creation_if_empty,
+    save_pod_analysis
 )
 
 from datetime import datetime, timezone, timedelta, time
@@ -284,14 +285,50 @@ class Pod:
         self.processStateDescription = reason
 
         timestamp = self.getTimestamp()
-        self.saveStatDataToCSV(timestamp, experiment_id)
+        # self.saveStatDataToCSV(timestamp, experiment_id)
         # self.saveCgroupMetricsToCSV(cgroups, timestamp, experiment_id)
-        self.saveClassificationToCsv(classification, self.podName, experiment_id)
+        # self.saveClassificationToCsv(classification, self.podName, experiment_id)
         summary["status"] = status.value
         summary["description"] = reason
-        self.saveSummaryToCsv(summary, self.podName, experiment_id)
+        # self.saveSummaryToCsv(summary, self.podName, experiment_id)
+        self.savePodAnalysisToDB(classification, summary, timestamp, experiment_id)
         # print("Pod status:", summary["status"])
         return self.isActiveResultProcess
+
+    def savePodAnalysisToDB(self, classification, summary, timestamp, experiment_id=None):
+        """프로세스 분석 결과(summary + classification)를 DB에 저장"""
+        def _state_value(state):
+            return state.value if hasattr(state, "value") else state
+
+        classifications = [
+            {
+                "pid": proc.get("pid"),
+                "comm": proc.get("comm"),
+                "state": _state_value(proc.get("state")),
+                "reason": proc.get("reason"),
+                "cputime_delta": proc.get("CPUtime_delta"),
+                "ctxt_delta": proc.get("ctxt_delta"),
+                "non_ctxt_delta": proc.get("non_ctxt_delta"),
+                "rss_delta": proc.get("rss_delta"),
+                "minflt_delta": proc.get("minflt_delta"),
+                "io_delta": proc.get("io_delta"),
+            }
+            for proc in classification
+        ]
+
+        analysis = {
+            "timestamp": timestamp,
+            "experiment_id": experiment_id,
+            "status": summary.get("status"),
+            "description": summary.get("description"),
+            "total": summary.get("total"),
+            "active": summary.get("active"),
+            "inactive": summary.get("inactive"),
+            "zombie": summary.get("zombie"),
+            "classifications": classifications,
+        }
+
+        save_pod_analysis(self.podName, self.namespace, analysis)
 
     def printProcList(self):
         print('-' * 50)
@@ -395,6 +432,7 @@ class Pod:
             return
 
         for process in self.processes:
+            m = process.metrics
             processes.append({
                 "timestamp": timestamp,
                 "pid": process.pid,
@@ -448,7 +486,12 @@ class Pod:
                 "arg_end": process.arg_end,
                 "env_start": process.env_start,
                 "env_end": process.env_end,
-                "exit_code": process.exit_code
+                "exit_code": process.exit_code,
+                "voluntary_ctxt_switches": m.voluntary_ctxt_switches if m else None,
+                "nonvoluntary_ctxt_switches": m.nonvoluntary_ctxt_switches if m else None,
+                "vm_rss": m.vm_rss if m else None,
+                "read_bytes": m.read_bytes if m else None,
+                "write_bytes": m.write_bytes if m else None
             })
 
         save_to_process(self.podName, self.namespace, processes)


### PR DESCRIPTION
## 개요
GC의 분석/판단 단계를 병렬화하고, 프로세스 분석 결과를 DB에 저장하며, 파드(in-cluster)로 배포·CI까지 가능하도록 구성합니다.

## 주요 변경
### 분석 로직
- 분석/판단 단계 `ThreadPoolExecutor` 병렬 처리
- GC 판단 조건을 히스토리 **AND** 프로세스 둘 다 비활성으로 변경
- `_calculateDeltas`에서 `ctxt_switches` None 가드

### DB 저장
- `pod_analysis`(summary) / `process_metrics`(ctxt·mem·io) / `process_classification` 테이블 추가
- `save_pod_analysis()`로 summary+classification 저장, `save_to_process`에 metrics 연동
- 프로세스 분석 결과를 CSV 대신 DB 저장으로 전환
- bash_history 예외 로그에 파드명 포함

### 배포 / CI
- `load_incluster_config()` 우선 적용, 실패 시 kubeconfig 폴백
- `Dockerfile` / `.dockerignore` 추가
- `deploy/gc-deployment.yaml`: k8s-gc SA/Role/RoleBinding/Deployment (swlabpods 대상 RBAC)
- `Jenkinsfile`: main 브랜치 Docker 빌드 → harbor 푸시(BUILD_NUMBER-GIT_SHA + latest) → k8s-gc 배포

## 배포 전 확인 필요
- Jenkins `harbor` 크리덴셜 / 에이전트 Docker·kubectl 환경 / 멀티브랜치 잡
- `k8s-gc` 네임스페이스, harbor imagePullSecret, DB(config.ini) 접근 경로
- metrics-server 설치 여부(resourceCollector가 metrics.k8s.io 사용)